### PR TITLE
add class name for inline blocks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ module.exports = options => {
     const customHighlightClassName = options.highlightClassName || `gridsome-highlight`;
     const codeTitleClassName = options.codeTitleClassName || 'gridsome-code-title';
     const classPrefix = options.classPrefix || 'language-';
+    const classPrefixInline = options.classPrefix || 'language-inline-';    
     const inlineCodeMarker = options.inlineCodeMarker || null;
     const aliases = options.aliases || {};
     const noInlineHighlight = options.noInlineHighlight || false;
@@ -95,7 +96,9 @@ module.exports = options => {
         );
         visit(tree, `inlineCode`, node => {
             let languageName = `text`
-      
+            
+            const classInlineName = `${classPrefixInline}${languageName}`
+
             if (inlineCodeMarker) {
               let [language, restOfValue] = node.value.split(`${inlineCodeMarker}`, 2)
               if (language && restOfValue) {
@@ -107,7 +110,7 @@ module.exports = options => {
             const className = `${classPrefix}${languageName}`
       
             node.type = `html`
-            node.value = `<code class="${className}">${highlightCode(
+            node.value = `<code class="${classInlineName}">${highlightCode(
               languageName,
               node.value
             )}</code>`


### PR DESCRIPTION
Hi

As mentioned in https://github.com/DavidCouronne/gridsome-plugin-remark-prismjs-all/issues/7, here is a little PR to give a different class name to inline code blocks. Instead of `language-${lang}` it sets it to `language-inline-${lang}`. The existing CSS in the prism theme will still be applied but can be overridden if desired. 

Let me know what you think, my js is a bit rough so I appreciate there may be a better solution!

Thanks again
Alex