### PR TITLE
Accessible line highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridsome-plugin-remark-prismjs-all",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Gridsome plugin prism syntax highlighting",
   "main": "src/index.js",
   "author": "David Couronné",

--- a/src/directives.js
+++ b/src/directives.js
@@ -51,7 +51,7 @@ const stripComment = line =>
   )
 
 const highlightWrap = line =>
-  [`<span class="gridsome-highlight-code-line">`, line, `</span>`].join(``)
+  [`<mark class="gridsome-highlight-code-line">`, line, `</mark>`].join(``)
 // const wrapAndStripComment = line => wrap(stripComment(line))
 
 const parseLine = (line, code, index, actions) => {


### PR DESCRIPTION
This change switches from `span` to `mark` for accessible line highlighting. This may not be very useful when it comes to the web apps visually; however, `mark` is correctly highlighted by applications that consume the content through RSS feeds or through text-to-speech systems.

Also, `span` is a generic inline element while `mark` is actually meant to convey the semantics of highlighting.